### PR TITLE
Possibly improve tab loading performance and add better logging

### DIFF
--- a/add-on/content/SerpProcess.jsm
+++ b/add-on/content/SerpProcess.jsm
@@ -1,0 +1,125 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+const EXPORTED_SYMBOLS = ["SerpProcess"];
+
+/**
+ * A map of search domains with their expected codes.
+ */
+let searchDomains = [{
+  "domains": [ "search.yahoo.co.jp" ],
+  "search": "p",
+  "followOnSearch": "ai",
+  "prefix": "fr",
+  "codes": ["mozff"],
+  "sap": "yahoo",
+}, {
+  "domains": [ "www.bing.com" ],
+  "search": "q",
+  "prefix": "pc",
+  "reportPrefix": "form",
+  "codes": ["MOZI"],
+  "sap": "bing",
+}, {
+  // The Yahoo domains to watch for.
+  "domains": [
+    "search.yahoo.com", "ca.search.yahoo.com", "hk.search.yahoo.com",
+    "tw.search.yahoo.com"
+  ],
+  "search": "p",
+  "followOnSearch": "fr2",
+  "prefix": "hspart",
+  "reportPrefix": "hsimp",
+  "codes": ["mozilla"],
+  "sap": "yahoo",
+}, {
+  // The Yahoo legacy domains.
+  "domains": [
+    "no.search.yahoo.com", "ar.search.yahoo.com", "br.search.yahoo.com",
+    "ch.search.yahoo.com", "cl.search.yahoo.com", "de.search.yahoo.com",
+    "uk.search.yahoo.com", "es.search.yahoo.com", "espanol.search.yahoo.com",
+    "fi.search.yahoo.com", "fr.search.yahoo.com", "nl.search.yahoo.com",
+    "id.search.yahoo.com", "in.search.yahoo.com", "it.search.yahoo.com",
+    "mx.search.yahoo.com", "se.search.yahoo.com", "sg.search.yahoo.com",
+  ],
+  "search": "p",
+  "followOnSearch": "fr2",
+  "prefix": "fr",
+  "codes": ["moz35"],
+  "sap": "yahoo",
+}, {
+  // The Google domains.
+  "domains": [
+    "www.google.com", "www.google.ac", "www.google.ad", "www.google.ae",
+    "www.google.com.af", "www.google.com.ag", "www.google.com.ai",
+    "www.google.al", "www.google.am", "www.google.co.ao", "www.google.com.ar",
+    "www.google.as", "www.google.at", "www.google.com.au", "www.google.az",
+    "www.google.ba", "www.google.com.bd", "www.google.be", "www.google.bf",
+    "www.google.bg", "www.google.com.bh", "www.google.bi", "www.google.bj",
+    "www.google.com.bn", "www.google.com.bo", "www.google.com.br",
+    "www.google.bs", "www.google.bt", "www.google.co.bw", "www.google.by",
+    "www.google.com.bz", "www.google.ca", "www.google.com.kh", "www.google.cc",
+    "www.google.cd", "www.google.cf", "www.google.cat", "www.google.cg",
+    "www.google.ch", "www.google.ci", "www.google.co.ck", "www.google.cl",
+    "www.google.cm", "www.google.cn", "www.google.com.co", "www.google.co.cr",
+    "www.google.com.cu", "www.google.cv", "www.google.cx", "www.google.com.cy",
+    "www.google.cz", "www.google.de", "www.google.dj", "www.google.dk",
+    "www.google.dm", "www.google.com.do", "www.google.dz", "www.google.com.ec",
+    "www.google.ee", "www.google.com.eg", "www.google.es", "www.google.com.et",
+    "www.google.eu", "www.google.fi", "www.google.com.fj", "www.google.fm",
+    "www.google.fr", "www.google.ga", "www.google.ge", "www.google.gf",
+    "www.google.gg", "www.google.com.gh", "www.google.com.gi", "www.google.gl",
+    "www.google.gm", "www.google.gp", "www.google.gr", "www.google.com.gt",
+    "www.google.gy", "www.google.com.hk", "www.google.hn", "www.google.hr",
+    "www.google.ht", "www.google.hu", "www.google.co.id", "www.google.iq",
+    "www.google.ie", "www.google.co.il", "www.google.im", "www.google.co.in",
+    "www.google.io", "www.google.is", "www.google.it", "www.google.je",
+    "www.google.com.jm", "www.google.jo", "www.google.co.jp", "www.google.co.ke",
+    "www.google.ki", "www.google.kg", "www.google.co.kr", "www.google.com.kw",
+    "www.google.kz", "www.google.la", "www.google.com.lb", "www.google.com.lc",
+    "www.google.li", "www.google.lk", "www.google.co.ls", "www.google.lt",
+    "www.google.lu", "www.google.lv", "www.google.com.ly", "www.google.co.ma",
+    "www.google.md", "www.google.me", "www.google.mg", "www.google.mk",
+    "www.google.ml", "www.google.com.mm", "www.google.mn", "www.google.ms",
+    "www.google.com.mt", "www.google.mu", "www.google.mv", "www.google.mw",
+    "www.google.com.mx", "www.google.com.my", "www.google.co.mz",
+    "www.google.com.na", "www.google.ne", "www.google.nf", "www.google.com.ng",
+    "www.google.com.ni", "www.google.nl", "www.google.no", "www.google.com.np",
+    "www.google.nr", "www.google.nu", "www.google.co.nz", "www.google.com.om",
+    "www.google.com.pk", "www.google.com.pa", "www.google.com.pe",
+    "www.google.com.ph", "www.google.pl", "www.google.com.pg", "www.google.pn",
+    "www.google.com.pr", "www.google.ps", "www.google.pt", "www.google.com.py",
+    "www.google.com.qa", "www.google.ro", "www.google.rs", "www.google.ru",
+    "www.google.rw", "www.google.com.sa", "www.google.com.sb", "www.google.sc",
+    "www.google.se", "www.google.com.sg", "www.google.sh", "www.google.si",
+    "www.google.sk", "www.google.com.sl", "www.google.sn", "www.google.sm",
+    "www.google.so", "www.google.st", "www.google.sr", "www.google.com.sv",
+    "www.google.td", "www.google.tg", "www.google.co.th", "www.google.com.tj",
+    "www.google.tk", "www.google.tl", "www.google.tm", "www.google.to",
+    "www.google.tn", "www.google.com.tr", "www.google.tt", "www.google.com.tw",
+    "www.google.co.tz", "www.google.com.ua", "www.google.co.ug",
+    "www.google.co.uk", "www.google.us", "www.google.com.uy", "www.google.co.uz",
+    "www.google.com.vc", "www.google.co.ve", "www.google.vg", "www.google.co.vi",
+    "www.google.com.vn", "www.google.vu", "www.google.ws", "www.google.co.za",
+    "www.google.co.zm", "www.google.co.zw",
+  ],
+  "search": "q",
+  "prefix": "client",
+  "followOnSearch": "oq",
+  "codes": ["firefox-b-ab", "firefox-b"],
+  "sap": "google",
+}];
+
+this.SerpProcess = {
+  getSearchDomainCodes(host) {
+    for (let domainInfo of searchDomains) {
+      if (domainInfo.domains.includes(host)) {
+        return domainInfo;
+      }
+    }
+    return null;
+  }
+}

--- a/add-on/content/serp-fs.js
+++ b/add-on/content/serp-fs.js
@@ -9,127 +9,13 @@
 const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.importGlobalProperties(["URLSearchParams"]);
+XPCOMUtils.defineLazyModuleGetter(this, "SerpProcess",
+  "chrome://searchvolmodel/content/SerpProcess.jsm");
 
 const kExtensionID = "searchvolmodel@mozilla.com";
 const kRegisterSerpMsg = `${kExtensionID}:register-serp`;
 const kDeregisterSerpMsg = `${kExtensionID}:deregister-serp`;
 const kShutdownMsg = `${kExtensionID}:shutdown`;
-
-/**
- * A map of search domains with their expected codes.
- */
-let searchDomains = [{
-  "domains": [ "search.yahoo.co.jp" ],
-  "search": "p",
-  "followOnSearch": "ai",
-  "prefix": "fr",
-  "codes": ["mozff"],
-  "sap": "yahoo",
-}, {
-  "domains": [ "www.bing.com" ],
-  "search": "q",
-  "prefix": "pc",
-  "reportPrefix": "form",
-  "codes": ["MOZI"],
-  "sap": "bing",
-}, {
-  // The Yahoo domains to watch for.
-  "domains": [
-    "search.yahoo.com", "ca.search.yahoo.com", "hk.search.yahoo.com",
-    "tw.search.yahoo.com"
-  ],
-  "search": "p",
-  "followOnSearch": "fr2",
-  "prefix": "hspart",
-  "reportPrefix": "hsimp",
-  "codes": ["mozilla"],
-  "sap": "yahoo",
-}, {
-  // The Yahoo legacy domains.
-  "domains": [
-    "no.search.yahoo.com", "ar.search.yahoo.com", "br.search.yahoo.com",
-    "ch.search.yahoo.com", "cl.search.yahoo.com", "de.search.yahoo.com",
-    "uk.search.yahoo.com", "es.search.yahoo.com", "espanol.search.yahoo.com",
-    "fi.search.yahoo.com", "fr.search.yahoo.com", "nl.search.yahoo.com",
-    "id.search.yahoo.com", "in.search.yahoo.com", "it.search.yahoo.com",
-    "mx.search.yahoo.com", "se.search.yahoo.com", "sg.search.yahoo.com",
-  ],
-  "search": "p",
-  "followOnSearch": "fr2",
-  "prefix": "fr",
-  "codes": ["moz35"],
-  "sap": "yahoo",
-}, {
-  // The Google domains.
-  "domains": [
-    "www.google.com", "www.google.ac", "www.google.ad", "www.google.ae",
-    "www.google.com.af", "www.google.com.ag", "www.google.com.ai",
-    "www.google.al", "www.google.am", "www.google.co.ao", "www.google.com.ar",
-    "www.google.as", "www.google.at", "www.google.com.au", "www.google.az",
-    "www.google.ba", "www.google.com.bd", "www.google.be", "www.google.bf",
-    "www.google.bg", "www.google.com.bh", "www.google.bi", "www.google.bj",
-    "www.google.com.bn", "www.google.com.bo", "www.google.com.br",
-    "www.google.bs", "www.google.bt", "www.google.co.bw", "www.google.by",
-    "www.google.com.bz", "www.google.ca", "www.google.com.kh", "www.google.cc",
-    "www.google.cd", "www.google.cf", "www.google.cat", "www.google.cg",
-    "www.google.ch", "www.google.ci", "www.google.co.ck", "www.google.cl",
-    "www.google.cm", "www.google.cn", "www.google.com.co", "www.google.co.cr",
-    "www.google.com.cu", "www.google.cv", "www.google.cx", "www.google.com.cy",
-    "www.google.cz", "www.google.de", "www.google.dj", "www.google.dk",
-    "www.google.dm", "www.google.com.do", "www.google.dz", "www.google.com.ec",
-    "www.google.ee", "www.google.com.eg", "www.google.es", "www.google.com.et",
-    "www.google.eu", "www.google.fi", "www.google.com.fj", "www.google.fm",
-    "www.google.fr", "www.google.ga", "www.google.ge", "www.google.gf",
-    "www.google.gg", "www.google.com.gh", "www.google.com.gi", "www.google.gl",
-    "www.google.gm", "www.google.gp", "www.google.gr", "www.google.com.gt",
-    "www.google.gy", "www.google.com.hk", "www.google.hn", "www.google.hr",
-    "www.google.ht", "www.google.hu", "www.google.co.id", "www.google.iq",
-    "www.google.ie", "www.google.co.il", "www.google.im", "www.google.co.in",
-    "www.google.io", "www.google.is", "www.google.it", "www.google.je",
-    "www.google.com.jm", "www.google.jo", "www.google.co.jp", "www.google.co.ke",
-    "www.google.ki", "www.google.kg", "www.google.co.kr", "www.google.com.kw",
-    "www.google.kz", "www.google.la", "www.google.com.lb", "www.google.com.lc",
-    "www.google.li", "www.google.lk", "www.google.co.ls", "www.google.lt",
-    "www.google.lu", "www.google.lv", "www.google.com.ly", "www.google.co.ma",
-    "www.google.md", "www.google.me", "www.google.mg", "www.google.mk",
-    "www.google.ml", "www.google.com.mm", "www.google.mn", "www.google.ms",
-    "www.google.com.mt", "www.google.mu", "www.google.mv", "www.google.mw",
-    "www.google.com.mx", "www.google.com.my", "www.google.co.mz",
-    "www.google.com.na", "www.google.ne", "www.google.nf", "www.google.com.ng",
-    "www.google.com.ni", "www.google.nl", "www.google.no", "www.google.com.np",
-    "www.google.nr", "www.google.nu", "www.google.co.nz", "www.google.com.om",
-    "www.google.com.pk", "www.google.com.pa", "www.google.com.pe",
-    "www.google.com.ph", "www.google.pl", "www.google.com.pg", "www.google.pn",
-    "www.google.com.pr", "www.google.ps", "www.google.pt", "www.google.com.py",
-    "www.google.com.qa", "www.google.ro", "www.google.rs", "www.google.ru",
-    "www.google.rw", "www.google.com.sa", "www.google.com.sb", "www.google.sc",
-    "www.google.se", "www.google.com.sg", "www.google.sh", "www.google.si",
-    "www.google.sk", "www.google.com.sl", "www.google.sn", "www.google.sm",
-    "www.google.so", "www.google.st", "www.google.sr", "www.google.com.sv",
-    "www.google.td", "www.google.tg", "www.google.co.th", "www.google.com.tj",
-    "www.google.tk", "www.google.tl", "www.google.tm", "www.google.to",
-    "www.google.tn", "www.google.com.tr", "www.google.tt", "www.google.com.tw",
-    "www.google.co.tz", "www.google.com.ua", "www.google.co.ug",
-    "www.google.co.uk", "www.google.us", "www.google.com.uy", "www.google.co.uz",
-    "www.google.com.vc", "www.google.co.ve", "www.google.vg", "www.google.co.vi",
-    "www.google.com.vn", "www.google.vu", "www.google.ws", "www.google.co.za",
-    "www.google.co.zm", "www.google.co.zw",
-  ],
-  "search": "q",
-  "prefix": "client",
-  "followOnSearch": "oq",
-  "codes": ["firefox-b-ab", "firefox-b"],
-  "sap": "google",
-}];
-
-function getSearchDomainCodes(host) {
-  for (let domainInfo of searchDomains) {
-    if (domainInfo.domains.includes(host)) {
-      return domainInfo;
-    }
-  }
-  return null;
-}
 
 /**
  * Used for debugging to log messages.
@@ -191,7 +77,7 @@ var serpProgressListener = {
       }
       log(`>>>>3\n`);
 
-      let domainInfo = getSearchDomainCodes(aLocation.host);
+      let domainInfo = SerpProcess.getSearchDomainCodes(aLocation.host);
       if (!domainInfo) {
         sendDeregisterSerpMsg(triggerURI.spec);
         return;

--- a/add-on/install.rdf
+++ b/add-on/install.rdf
@@ -14,7 +14,7 @@
     <em:targetApplication>
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
-        <em:minVersion>52.0</em:minVersion>
+        <em:minVersion>55.0</em:minVersion>
         <em:maxVersion>59.*</em:maxVersion>
       </Description>
     </em:targetApplication>

--- a/scripts/user.js
+++ b/scripts/user.js
@@ -1,3 +1,5 @@
+/* global user_pref */
+
 // Bug 1393805 - Need to lower the security level for now.
 user_pref("security.sandbox.content.level", 2);
 


### PR DESCRIPTION
Whilst looking for other information, I discovered we can probably improve the loading performance per-tab and avoid the overhead of loading the large objects for each tab - doing it once per process:

https://developer.mozilla.org/en-US/Firefox/Multiprocess_Firefox/Message_Manager/Performance#Declaring_stateless_functions_once_per_process

Additionally, I'm switching to Log.jsm, for better logging - especially different levels. We might take some of it out eventually, but I also think it is useful to leave some of it in, and have at least two different levels. Log.jsm seems to make this easier.