### PR TITLE
Fixes handling of clicks in the observer & changes tracking to individual tabs

### DIFF
--- a/add-on/bootstrap.js
+++ b/add-on/bootstrap.js
@@ -43,7 +43,7 @@ function handleRegisterSerpMsg(message) {
 
   let info = message.data;
   log.debug(message.name, message.data);
-  SerpMonitor.serpTabs.set(info.url, info);
+  SerpMonitor.addSerpTab(info.url, message.target, info);
 }
 
 /**
@@ -58,7 +58,7 @@ function handleDeregisterSerpMsg(message) {
 
   let info = message.data;
   log.debug(message.name, message.data);
-  SerpMonitor.serpTabs.delete(info.url);
+  SerpMonitor.removeSerpTab(info.url, message.target);
 }
 
 /**
@@ -72,7 +72,7 @@ function activateTelemetry() {
   gTelemetryActivated = true;
 
   Services.mm.addMessageListener(kRegisterSerpMsg, handleRegisterSerpMsg);
-  Services.mm.addMessageListener(kDeregisterSerpMsg, handleDeregisterSerpMsg);
+  Services.mm.addMessageListener(kDeregisterSerpMsg, handleDeregisterSerpMsg, true);
   Services.mm.loadFrameScript(frameScript, true);
   Cc["@mozilla.org/network/http-activity-distributor;1"]
     .getService(Ci.nsIHttpActivityDistributor)

--- a/add-on/content/SerpMonitor.jsm
+++ b/add-on/content/SerpMonitor.jsm
@@ -94,7 +94,30 @@ let searchResultDomains = [{
 this.SerpMonitor = {
   // A map of tab URLs being monitored to search domain information. These are
   // tabs where the last visited page was a SERP.
-  serpTabs: new Map(),
+  _serpTabs: new Map(),
+
+  addSerpTab(url, browser, info) {
+    let item = this._serpTabs.get(url);
+    if (item) {
+      item.browsers.push(browser);
+    } else {
+      this._serpTabs.set(url, {info, browsers: [browser]});
+    }
+  },
+
+  removeSerpTab(url, browser) {
+    let item = this._serpTabs.get(url);
+    if (item) {
+      let index = item.browsers.indexOf(browser);
+      if (index != -1) {
+        item.browsers.splice(index, 1);
+      }
+
+      if (!item.browsers.length) {
+        this._serpTabs.delete(url);
+      }
+    }
+  },
 
   searchResultDomains,
 
@@ -108,8 +131,9 @@ this.SerpMonitor = {
   },
 
   observeActivity(aHttpChannel, aActivityType, aActivitySubtype, aTimestamp, aExtraSizeData, aExtraStringData) {
-    if (aActivityType != Ci.nsIHttpActivityObserver.ACTIVITY_TYPE_HTTP_TRANSACTION &&
-        aActivitySubtype != Ci.nsIHttpActivityObserver.ACTIVITY_SUBTYPE_TRANSACTION_CLOSE) {
+    if (!this._serpTabs.size ||
+        (aActivityType != Ci.nsIHttpActivityObserver.ACTIVITY_TYPE_HTTP_TRANSACTION &&
+         aActivitySubtype != Ci.nsIHttpActivityObserver.ACTIVITY_SUBTYPE_TRANSACTION_CLOSE)) {
       return;
     }
 
@@ -131,21 +155,21 @@ this.SerpMonitor = {
         return;
       }
 
-      log.trace(`>>>> [${[...this.serpTabs.keys()]}]\n`);
+      log.trace(`>>>> [${[...this._serpTabs.keys()]}]\n`);
       if (triggerURI) {
-        log.trace(`>>>> triggeringPrincipal in map: ${this.serpTabs.has(triggerURI.spec)}`);
+        log.trace(`>>>> triggeringPrincipal in map: ${this._serpTabs.has(triggerURI.spec)}`);
         log.trace(`>>>> triggeringPrincipal: ${triggerURI.spec}`);
       }
-      log.trace(`>>>> channel.URI: ${uri.spec}`);
+      log.info(`>>>> channel.URI: ${uri.spec}`);
       if (resultDomainInfo &&
         uri.filePath.substring(1).startsWith(resultDomainInfo.prefix) &&
-                 this.serpTabs.has(triggerURI.spec)) {
-        let info = this.serpTabs.get(triggerURI.spec);
+                 this._serpTabs.has(triggerURI.spec)) {
+        let info = this._serpTabs.get(triggerURI.spec).info;
 
         let histogram = Services.telemetry.getKeyedHistogramById("SEARCH_COUNTS");
         log.info(`Reporting to Telemetry: ${info.sap}.adclick:unknown:${info.code}`);
         histogram.add(`${info.sap}.adclick:unknown:${info.code}`);
-        this.serpTabs.delete(triggerURI.spec);
+        this._serpTabs.delete(triggerURI.spec);
       }
     } catch (e) {
       Cu.reportError(e);

--- a/add-on/content/serp-fs.js
+++ b/add-on/content/serp-fs.js
@@ -98,6 +98,8 @@ var serpProgressListener = {
             code = queries.get(domainInfo.reportPrefix);
           }
           if (aLocation.spec != gLastSearch) {
+            // This is a new SERP, but is different from the old one,
+            // so we should deregister the old one before registering the new.
             deregisterSerp();
           }
           sendRegisterSerpMsg(code, domainInfo.sap, aLocation.spec);


### PR DESCRIPTION
This fixes the handling of clicks in the observer (the boolean check for the activity observer was incorrect and letting through reports for anything that was http and was not "close").

It also changes the active search tracking so that active urls are recorded on a per-tab basis, and will correctly be added/removed in the case of visiting other pages, or returning to a previous search page.

Fixes #2 and Fixes #5 