### PR TITLE
Fix installation of add-on, and reduce logging at info level

### DIFF
--- a/add-on/bootstrap.js
+++ b/add-on/bootstrap.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/* global APP_SHUTDOWN:false */
+
 "use strict";
 
 const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
@@ -140,10 +142,7 @@ var cohortManager = {
  * @param {Number} reason Indicates why the extension is being installed.
  */
 function install(data, reason) {
-  cohortManager.init();
-  if (cohortManager.enableForUser) {
-    activateTelemetry();
-  }
+  // Nothing specifically to do, startup will set everything up for us.
 }
 
 /**
@@ -153,7 +152,7 @@ function install(data, reason) {
  * @param {Number} reason Indicates why the extension is being uninstalled.
  */
 function uninstall(data, reason) {
-  deactivateTelemetry();
+  // Nothing specifically to do, shutdown does what we need.
 }
 
 /**
@@ -182,5 +181,10 @@ function startup(data, reason) {
  * @param {Number} reason Indicates why the extension is being shut down.
  */
 function shutdown(data, reason) {
+  // If we're shutting down, skip the cleanup to save time.
+  if (reason === APP_SHUTDOWN) {
+    return;
+  }
+
   deactivateTelemetry();
 }

--- a/add-on/content/SerpMonitor.jsm
+++ b/add-on/content/SerpMonitor.jsm
@@ -172,7 +172,7 @@ this.SerpMonitor = {
         log.trace(`>>>> triggeringPrincipal in map: ${this._serpTabs.has(triggerURI.spec)}`);
         log.trace(`>>>> triggeringPrincipal: ${triggerURI.spec}`);
       }
-      log.info(`>>>> channel.URI: ${uri.spec}`);
+      log.trace(`>>>> channel.URI: ${uri.spec}`);
       if (resultDomainInfo &&
           uri.filePath.substring(1).startsWith(resultDomainInfo.prefix) &&
           this._serpTabs.has(triggerURI.spec)) {


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/Add-ons/Bootstrapped_extensions#startup, startup gets called at installation and at other times.

Hence we don't need to do our initialisation on install - doing so causes errors that then stop the add-on starting up correctly.

This fixes that.

I've also just tidied up a bit of logging to make it easier for QA to test the add-on.